### PR TITLE
adding the function get_all which returns all matches if the file nam…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,75 @@ foo.tar
        - ghi
 ```
 
-This library will allow reading the contents of the files in this nested archive in
-the following "seamless" manner:
-```
+This library provides two main functions for accessing files in nested archives:
+
+## `get()` - Single File Access
+Reads the contents of a single file in a nested archive:
+```python
 nestedarchive.get("/tmp/foobar/foo.tar/foo1")
 nestedarchive.get("/tmp/foobar/foo.tar/abc/def")
 nestedarchive.get("/tmp/foobar/foo.tar/bar.tar/bar1")
 nestedarchive.get("/tmp/foobar/foo.tar/bar.tar/foo3.tar.gz/foo4")
 ```
 
-Globs are also supported - all matches are tried until one is found that (eventually) contains the expected file, e.g.:
-```
-- nestedarchive.get("/tmp/foobar/foo.tar/bar.tar/foo*.tar.gz/foo7")
+Globs are supported - all matches are tried until one is found that (eventually) contains the expected file:
+```python
+nestedarchive.get("/tmp/foobar/foo.tar/bar.tar/foo*.tar.gz/foo7")
 ```
 Will first silently try `foo3.tar.gz` and fail because it does not contain `foo7`, then it will try `foo6.tar.gz` and
 succeed because `foo6.tar.gz` contains `foo7`
+
+## `get_all()` - Multiple File Discovery
+Returns all files and directories matching a glob pattern as Path objects:
+```python
+# Get all .txt files
+results = nestedarchive.get_all("/tmp/foobar/foo.tar/*.txt")
+for filepath in results:
+    print(f"Found file: {filepath}")
+    with open(filepath, 'r') as f:
+        content = f.read()
+        print(f"Content: {content}")
+
+# Get all items in a directory (files and directories)
+results = nestedarchive.get_all("/tmp/foobar/foo.tar/bar.tar/*")
+for path in results:
+    if path.is_dir():
+        print(f"Directory: {path}")
+    else:
+        print(f"File: {path}")
+
+# Get all files in nested archives
+results = nestedarchive.get_all("/tmp/foobar/foo.tar/bar.tar/foo*.tar.gz/*")
+for filepath in results:
+    print(f"File in nested archive: {filepath}")
+```
+
+## API Comparison
+
+| Function | Purpose | Returns | Use Case |
+|----------|---------|---------|----------|
+| `get()` | Read single file content | File content (str/bytes) or Path | Get specific file content |
+| `get_all()` | Find multiple files/directories | List of Path objects | Discover and process multiple files |
+
+## Installation and Usage
+
+```python
+import nestedarchive
+
+# Single file access
+content = nestedarchive.get("/path/to/archive.tar/file.txt")
+print(content)
+
+# Multiple file discovery
+file_paths = nestedarchive.get_all("/path/to/archive.tar/*.log")
+for path in file_paths:
+    print(f"Log file: {path}")
+
+# Working with remote archives
+archive = nestedarchive.RemoteNestedArchive("https://example.com/archive.tar")
+content = archive.get("/nested/path/file.txt")
+file_paths = archive.get_all("/nested/path/*.txt")
+```
 
 Currently supported extensions:
 - tar

--- a/nestedarchive/__init__.py
+++ b/nestedarchive/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.2.4"
 
-from .get import get
+from .get import get, get_all
 from .remote import RemoteNestedArchive
 

--- a/nestedarchive/get.py
+++ b/nestedarchive/get.py
@@ -1,7 +1,7 @@
 import os
 import tarfile
 from pathlib import Path
-from typing import Union
+from typing import Union, List
 
 
 def get(nested_archive_path: Union[str, Path], mode="r"):
@@ -10,6 +10,39 @@ def get(nested_archive_path: Union[str, Path], mode="r"):
     """
     nested_archive_path = Path(nested_archive_path)
     return _get_recurse(nested_archive_path, cwd=Path.cwd(), mode=mode, original=nested_archive_path)
+
+
+def get_all(nested_archive_path: Union[str, Path], mode="r") -> List[Path]:
+    """
+    Similar to get(), but returns all matches for glob patterns instead of just the first one.
+    Returns a list of Path objects for all matches.
+    
+    Args:
+        nested_archive_path: Path to the nested archive file or directory
+        mode: File opening mode (default: "r" for text, "rb" for binary)
+        
+    Returns:
+        List of Path objects for all matching files and directories.
+        
+    Examples:
+        >>> # Get all .txt files in a nested archive
+        >>> results = get_all("/tmp/archive.tar/foo*.txt")
+        >>> for filepath in results:
+        ...     print(f"File: {filepath}")
+        ...     with open(filepath, 'r') as f:
+        ...         content = f.read()
+        ...         print(f"Content: {content}")
+        
+        >>> # Get all items matching a pattern (could be files or directories)
+        >>> results = get_all("/tmp/archive.tar/bar.tar/*")
+        >>> for path in results:
+        ...     if path.is_dir():
+        ...         print(f"Directory: {path}")
+        ...     else:
+        ...         print(f"File: {path}")
+    """
+    nested_archive_path = Path(nested_archive_path)
+    return _get_all_recurse(nested_archive_path, cwd=Path.cwd(), mode=mode, original=nested_archive_path)
 
 
 def _get_recurse(nested_archive_path: Path, cwd: Path, mode: str, original: Path) -> Union[Path, Union[str, bytes]]:
@@ -52,6 +85,53 @@ def _get_recurse(nested_archive_path: Path, cwd: Path, mode: str, original: Path
         except UnicodeDecodeError as e:
             raise RuntimeError("""Looks like you're trying to get a non utf-8 encoded file, try using the mode="rb" kwarg for the get method""") from e
 
+    # Non-terminal case - process candidates and recurse
+    return _process_candidates(current, rest_of_segments, cwd, mode, original)
+
+
+def _get_all_recurse(nested_archive_path: Path, cwd: Path, mode: str, original: Path) -> List[Path]:
+    """
+    Recursively processes nested archives and returns ALL matches for glob patterns.
+    Similar to _get_recurse but collects all results instead of returning the first match.
+    Returns Path objects for all matches (both files and directories).
+    """
+    root_segment, *rest_of_segments = nested_archive_path.parts
+    current = cwd / root_segment
+
+    # Terminal case - we reached the end of the path
+    if len(rest_of_segments) == 0:
+        # Get ALL matches for glob pattern (could be files, directories, or both)
+        matches = list(current.parent.glob(current.name))
+        if not matches:
+            other_files = os.linesep.join(map(lambda path: path.name, current.parent.iterdir()))
+            raise FileNotFoundError(
+                f"Couldn't find any files matching {current}, but I found these other files:{os.linesep}{other_files}")
+
+        # Return all matches as Path objects
+        return matches
+
+    # Non-terminal case - process candidates and collect all results
+    return _process_all_candidates(current, rest_of_segments, cwd, mode, original)
+
+
+def _process_candidates(current: Path, rest_of_segments: list, cwd: Path, mode: str, original: Path) -> Union[Path, Union[str, bytes]]:
+    """
+    Process candidates for non-terminal case (when there are more path segments to process).
+    Handles glob patterns and tries each candidate until one succeeds.
+    
+    Args:
+        current: Current path segment being processed
+        rest_of_segments: Remaining path segments to process
+        cwd: Current working directory
+        mode: File opening mode
+        original: Original path for error reporting
+        
+    Returns:
+        Result from the first successful candidate
+        
+    Raises:
+        FileNotFoundError: If no candidates succeed
+    """
     # Support globs - see README for more information
     exceptions = []
     for candidate in current.parent.glob(current.name) if current.name != "" else (current,):
@@ -84,6 +164,61 @@ def _get_recurse(nested_archive_path: Path, cwd: Path, mode: str, original: Path
                                "")
         raise FileNotFoundError(
             f"Couldn't find any files matching {original}{encountered_message}")
+
+
+def _process_all_candidates(current: Path, rest_of_segments: list, cwd: Path, mode: str, original: Path) -> List[Path]:
+    """
+    Process candidates for non-terminal case and collect ALL results for glob patterns.
+    Similar to _process_candidates but collects all successful results instead of returning the first one.
+    Returns Path objects for all matches (both files and directories).
+    
+    Args:
+        current: Current path segment being processed
+        rest_of_segments: Remaining path segments to process
+        cwd: Current working directory
+        mode: File opening mode
+        original: Original path for error reporting
+        
+    Returns:
+        List of all successful results from all candidates
+        
+    Raises:
+        FileNotFoundError: If no candidates succeed
+    """
+    all_results = []
+    exceptions = []
+    
+    for candidate in current.parent.glob(current.name) if current.name != "" else (current,):
+        try:
+            if candidate.is_dir():
+                # Simply recurse into regular directories, no unarchiving needed
+                results = _get_all_recurse(Path(*rest_of_segments), cwd=candidate, mode=mode, original=original)
+                all_results.extend(results)
+            else:
+                # Handle archive extraction and recurse
+                extracted = cwd / _nestedarchive_extracted_tar_name(candidate.name)
+                
+                if not extracted.exists():
+                    try:
+                        tarfile.open(candidate).extractall(path=extracted)
+                    except tarfile.ReadError as e:
+                        ex = ValueError(f"Python's tarfile module failed to open {candidate}, file type unsupported")
+                        ex.__cause__ = e
+                        exceptions.append(ex)
+                        continue
+                
+                results = _get_all_recurse(Path(*rest_of_segments), cwd=extracted, mode=mode, original=original)
+                all_results.extend(results)
+        except FileNotFoundError as e:
+            exceptions.append(e)
+    
+    if not all_results and exceptions:
+        encountered_message = (f". Errors encountered:{os.linesep}{os.linesep.join(map(str, exceptions))}"
+                               if len(exceptions) != 0 else
+                               "")
+        raise FileNotFoundError(f"Couldn't find any files matching {original}{encountered_message}")
+    
+    return all_results
 
 
 def _nestedarchive_extracted_tar_name(original_archive):


### PR DESCRIPTION
…e is a file glob. It returns with a list which can have elements either pathlib.Path if the pattern matches a directory of a tuple which has the absolute file name as it's first element and the content of the matching file as the second argument. Should resolve https://github.com/omertuc/nestedarchive/issues/2